### PR TITLE
heroku project name fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Readit",
+  "name": "read-it",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
It looks like heroku doesn't like project names with capital letters.